### PR TITLE
Delete unneeded index.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Removed: layouts/index.js, because we move from layouts to routes.
 - Added: Initial support for Service Worker
   ([#343](https://github.com/MoOx/phenomic/pull/343))
 - Changed: Remove the ability to define a custom globby pattern via appcache option.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   ([#343](https://github.com/MoOx/phenomic/pull/343))
 
 ## Boilerplate
-- Removed: layouts/index.js, because we move from layouts to routes.
+
+- Removed: ``layouts/index.js``. It is not used since 0.10.0.
 
 # 0.10.2 - 2016-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
-- Removed: layouts/index.js, because we move from layouts to routes.
+
 - Added: Initial support for Service Worker
   ([#343](https://github.com/MoOx/phenomic/pull/343))
 - Changed: Remove the ability to define a custom globby pattern via appcache option.
   `appcache` option was deprecated and will be removed soon.
   You should update your configuration to use the latest `offline` option.
   ([#343](https://github.com/MoOx/phenomic/pull/343))
+
+## Boilerplate
+- Removed: layouts/index.js, because we move from layouts to routes.
 
 # 0.10.2 - 2016-04-14
 

--- a/boilerplate/web_modules/layouts/index.js
+++ b/boilerplate/web_modules/layouts/index.js
@@ -1,5 +1,0 @@
-export Page from "./Page" // default layout
-export PageError from "./PageError"
-
-// you can add your own layout here
-// eg: export Post from "Post"


### PR DESCRIPTION
Because we move from layouts to routes.