### PR TITLE
Add Remark plugin to transform gemoji shortcodes into emoji

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -59,6 +59,7 @@
     "redux": "^3.0.0",
     "remark": "^4.1.1",
     "remark-autolink-headings": "^3.0.0",
+    "remark-gemoji-to-emoji": "^1.0.0",
     "remark-highlight.js": "^3.0.0",
     "remark-html": "^3.0.0",
     "remark-slug": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "redbox-react": "^1.2.2",
     "remark": "^4.1.1",
     "remark-autolink-headings": "^3.0.0",
+    "remark-gemoji-to-emoji": "^1.0.0",
     "remark-highlight.js": "^3.0.0",
     "remark-html": "^3.0.0",
     "remark-slug": "^4.1.0",

--- a/src/content-loader/default-renderer.js
+++ b/src/content-loader/default-renderer.js
@@ -3,6 +3,7 @@ import slug from "remark-slug"
 import autoLinkHeadings from "remark-autolink-headings"
 import highlight from "remark-highlight.js"
 import html from "remark-html"
+import gemojiToEmoji from "remark-gemoji-to-emoji"
 
 export default (text) => (
   remark
@@ -22,6 +23,9 @@ export default (text) => (
 
     // https://github.com/ben-eb/remark-highlight.js
     .use(highlight)
+
+    // https://github.com/jackycute/remark-gemoji-to-emoji
+    .use(gemojiToEmoji)
 
     // render
     .process(text, {


### PR DESCRIPTION
I think it would be better if the user be able to use [Gemoji shortcodes](http://www.emoji-cheat-sheet.com/) for converting `:smile:` to :smile: