### PR TITLE
Add browser context to browser build

### DIFF
--- a/src/builder/webpack/config.browser.js
+++ b/src/builder/webpack/config.browser.js
@@ -1,12 +1,12 @@
 // @flow
 
 import { join } from "path"
-
+import { DefinePlugin } from "webpack"
 import commonWebpackConfig from "./config.common.js"
 import { offlinePlugin, offlineEntry } from "../../_utils/offline/webpack.js"
 
 const chunkNameBrowser = "phenomic.browser"
-
+const wrap = JSON.stringify
 export default (config: PhenomicConfig): WebpackConfig => {
   const webpackConfig = commonWebpackConfig(config)
 
@@ -15,6 +15,12 @@ export default (config: PhenomicConfig): WebpackConfig => {
 
     plugins: [
       ...webpackConfig.plugins,
+      new DefinePlugin({ 
+        "process.env": {
+          PHENOMIC_BROWSER_CONTEXT: wrap(true),
+        }
+      }),
+
       ...offlinePlugin(config),
     ],
 


### PR DESCRIPTION
#641

Add browser context global for webpack to not choke on node static build

Example usage here: https://gist.github.com/DavidWells/94df55e693d8ecf6de22576cf397f6e2

This fixes older npm packages referencing `window`, `document` etc. 

```
if (process.env.PHENOMIC_BROWSER_CONTEXT) {
  // is browser, include package that breaks in node
  var Auth0Lock = require('auth0-lock').default
}
```
