### PR TITLE
Docs: Change Learn C++ website

### DIFF
--- a/docs/content/showcase/entry/cpp.daynhauhoc.com.md
+++ b/docs/content/showcase/entry/cpp.daynhauhoc.com.md
@@ -1,6 +1,6 @@
 ---
 title: Learn C++ (Vietnamese)
-url: https://khoanguyen.me/dnh-cpp/
+url: http://cpp.daynhauhoc.com/
 source: https://github.com/thangngoc89/dnh-cpp/
 showcaseTags:
   - learning


### PR DESCRIPTION
I made some changes, and give it a proper domain. 

It uses Discourse Embed comment for comment system