### PR TITLE
Add className support to page container

### DIFF
--- a/src/PageContainer/component.js
+++ b/src/PageContainer/component.js
@@ -15,6 +15,7 @@ type Props = {
     splat: string,
   },
   layouts: Object,
+  className: string,
   defaultLayout: string,
   getPage: Function,
   setPageNotFound: Function,
@@ -234,7 +235,7 @@ class PageContainer extends Component<DefaultProps, Props, void> {
     const Layout = getLayout(page.type, props) || LayoutFallback
 
     return (
-      <div>
+      <div className={props.className}>
         {
           !page.error && page.loading && PageLoading &&
           <PageLoading />


### PR DESCRIPTION
I need access to the page container to apply a class.

My use case is to apply some fancy min height css to the page container to make it fit in viewport always

```
.pageContainer {
 min-height:  min-height: calc(100vh - $navHeight - $footerHeight);
}
```

![image](https://cloud.githubusercontent.com/assets/532272/18107383/7e3371a6-6ebc-11e6-94ee-4b4fc0f2e02b.png)
