### PR TITLE
Removed: ``PageContainer`` does not wrap its child into a ``<div>``

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # HEAD
 
+- Removed: ``PageContainer`` does not wrap its child into a ``<div>``
+  ([#691](https://github.com/MoOx/phenomic/pull/691) - @MoOx, based on @DavidWells [idea](https://github.com/MoOx/phenomic/pull/690))
+
 # 0.16.2 - 2016-08-23
 
 - Fixed: error during static build have an accurate stack trace.

--- a/src/PageContainer/__tests__/component.js
+++ b/src/PageContainer/__tests__/component.js
@@ -34,9 +34,7 @@ test("should render a Page if page is ok", () => {
     },
   )
   expect(renderer.getRenderOutput()).toEqualJSX(
-    <div>
-      <Page ref={ function noRefCheck() {} } />
-    </div>
+    <Page ref={ function noRefCheck() {} } />
   )
 })
 
@@ -92,13 +90,11 @@ available`, () => {
   )
 
   expect(renderer.getRenderOutput()).toEqualJSX(
-    <div>
-      <div style={ { "text-align": "center" } }>
-        <h1>
-          { "Test" }
-        </h1>
-        <p />
-      </div>
+    <div style={ { "text-align": "center" } }>
+      <h1>
+        { "Test" }
+      </h1>
+      <p />
     </div>
   )
 })
@@ -123,9 +119,7 @@ test("should render a PageError if page is not ok and PageError is available",
   )
 
   expect(renderer.getRenderOutput()).toEqualJSX(
-    <div>
-      <PageError error="Test" />
-    </div>
+    <PageError error="Test" />
   )
 })
 
@@ -149,8 +143,6 @@ test("should render a another page layout if defaultLayout is used", () => {
   )
 
   expect(renderer.getRenderOutput()).toEqualJSX(
-    <div>
-      <AnotherPage ref={ function noRefCheck() {} } />
-    </div>
+    <AnotherPage ref={ function noRefCheck() {} } />
   )
 })

--- a/src/PageContainer/component.js
+++ b/src/PageContainer/component.js
@@ -233,29 +233,27 @@ class PageContainer extends Component<DefaultProps, Props, void> {
     const LayoutFallback = getLayout(props.defaultLayout, props)
     const Layout = getLayout(page.type, props) || LayoutFallback
 
-    return (
-      <div>
-        {
-          !page.error && page.loading && PageLoading &&
-          <PageLoading />
-        }
-        {
-          !!page.error && !PageError &&
+    if (page.error) {
+      if (!PageError) {
+        return (
           <div style={ { "text-align": "center" } }>
             <h1>{ page.error }</h1>
             <p>{ page.errorText }</p>
           </div>
-        }
-        {
-          !!page.error && PageError &&
-          <PageError { ...page } />
-        }
-        {
-          !page.error && !page.loading && Layout &&
-          <Layout ref={ this.saveContentRef } { ...page } />
-        }
-      </div>
-    )
+        )
+      }
+      return <PageError { ...page } />
+    }
+    else {
+      if (page.loading && PageLoading) {
+        return <PageLoading />
+      }
+      else if (Layout) {
+        return <Layout ref={ this.saveContentRef } { ...page } />
+      }
+    }
+
+    return null
   }
 }
 


### PR DESCRIPTION
Closes #690 

poke @DavidWells 