### PR TITLE
Only clear /dist on prod build

### DIFF
--- a/src/builder/index.js
+++ b/src/builder/index.js
@@ -35,7 +35,12 @@ export default function(config: Object): void {
   config.webpackConfigNode = webpackConfigNode(config)
 
   const destination = join(config.cwd, config.destination)
-  fs.emptyDirSync(destination)
+  
+  if (config.production) {
+    // If production build, clear /dist folder
+    fs.emptyDirSync(destination)
+  }
+
 
   if (config.static) {
     // Copy static assets to build folder


### PR DESCRIPTION
This is running everytime and sometimes I want to look at the /dist without having to rebuild =P

`phenomic start` clears the dist folder and doesn't need to.

Only the `phenomic build` should clear the dist.
