### PR TITLE
Fix broken link

### DIFF
--- a/docs/content/docs/usage/gh-pages.md
+++ b/docs/content/docs/usage/gh-pages.md
@@ -3,7 +3,7 @@ title: Automatic deployment on GitHub Pages
 ---
 
 **Be sure that you use the ``phenomic.CNAME`` option in your
-[configuration](./configuration/)**
+[configuration](../configuration/)**
 
 You will have multiple possibilities to deploy your `dist` folder on the
 `gh-pages` branch.


### PR DESCRIPTION
Fix a broken link. Also, `CNAME` will only be needed if one want to set the sub-domain stuff, am i right? This line seems a little confusing that it it seems that we **should** set `CNAME` to true.