### PR TITLE
Added: Specify a folder for babel-loader temp dir

### DIFF
--- a/src/_utils/edit-webpack-loader-config/__tests__/convert-to-webpack-1.js
+++ b/src/_utils/edit-webpack-loader-config/__tests__/convert-to-webpack-1.js
@@ -1,0 +1,86 @@
+import test from "ava"
+import converter from "../convert-to-webpack-1"
+
+const scenarios = [
+  {
+    name: "single loader",
+    from: {
+      test: "foo",
+      loaders: [
+        {
+          loader: "foo-loader",
+          query: {
+            phenomic: "awesome",
+          },
+        },
+      ],
+    },
+    to: {
+      test: "foo",
+      loaders: [
+        "foo-loader?phenomic=awesome",
+      ],
+    },
+  },
+  {
+    name: "multiple loaders",
+    from: {
+      test: "foo",
+      loaders: [
+        {
+          loader: "foo-loader",
+          query: {
+            phenomic: "awesome",
+          },
+        },
+        {
+          loader: "bar-loader",
+        },
+      ],
+    },
+    to: {
+      test: "foo",
+      loaders: [
+        "foo-loader?phenomic=awesome",
+        "bar-loader",
+      ],
+    },
+  },
+  {
+    name: "multiple loaders with complex query string",
+    from: {
+      test: "foo",
+      loaders: [
+        {
+          loader: "foo-loader",
+          query: {
+            phenomic: "awesome",
+          },
+        },
+        {
+          loader: "bar-loader",
+          query: {
+            presets: [
+              "foo",
+              "bar",
+              "baz",
+            ],
+          },
+        },
+      ],
+    },
+    to: {
+      test: "foo",
+      loaders: [
+        "foo-loader?phenomic=awesome",
+        "bar-loader?presets=foo&presets=bar&presets=baz",
+      ],
+    },
+  },
+]
+
+test("convert to webpack 1 format from normalized webpack 2 format", (t) => {
+  scenarios.forEach((scenario) => {
+    t.deepEqual(converter(scenario.from), scenario.to, scenario.name)
+  })
+})

--- a/src/_utils/edit-webpack-loader-config/__tests__/convert-to-webpack-2.js
+++ b/src/_utils/edit-webpack-loader-config/__tests__/convert-to-webpack-2.js
@@ -1,0 +1,176 @@
+import test from "ava"
+import converter from "../convert-to-webpack-2"
+
+const scenarios = [
+  {
+    name: "should not touch un-relevant properties",
+    from: {
+      test: "foo",
+      loader: "foo-loader",
+      foo: "bar",
+      bar: "baz",
+    },
+    to: {
+      test: "foo",
+      foo: "bar",
+      bar: "baz",
+      loaders: [ {
+        loader: "foo-loader",
+      } ],
+    },
+  },
+  {
+    name: "loader: single loader with no query string",
+    from: {
+      test: "foo",
+      loader: "foo-loader",
+    },
+    to: {
+      test: "foo",
+      loaders: [ {
+        loader: "foo-loader",
+      } ],
+    },
+  },
+  {
+    name: "loader: single loader with query string",
+    from: {
+      test: "foo",
+      loader: "foo-loader?name=foo",
+    },
+    to: {
+      test: "foo",
+      loaders: [ {
+        loader: "foo-loader",
+        query: {
+          name: "foo",
+        },
+      } ],
+    },
+  },
+  {
+    name: "loader: multiple loader with no query string",
+    from: {
+      test: "foo",
+      loader: "foo-loader!bar-loader",
+    },
+    to: {
+      test: "foo",
+      loaders: [
+        {
+          loader: "foo-loader",
+        },
+        {
+          loader: "bar-loader",
+        },
+      ],
+    },
+  },
+  {
+    name: "loader: multiple loader with query string on 1 loader",
+    from: {
+      test: "foo",
+      loader: "foo-loader!bar-loader?name=foo",
+    },
+    to: {
+      test: "foo",
+      loaders: [
+        {
+          loader: "foo-loader",
+        },
+        {
+          loader: "bar-loader",
+          query: {
+            name: "foo",
+          },
+        },
+      ],
+    },
+  },
+  {
+    name: "loader: multiple loader with query string on all of them",
+    from: {
+      test: "foo",
+      loader: "foo-loader?phenomic=awesome!bar-loader?name=foo",
+    },
+    to: {
+      test: "foo",
+      loaders: [
+        {
+          loader: "foo-loader",
+          query: {
+            phenomic: "awesome",
+          },
+        },
+        {
+          loader: "bar-loader",
+          query: {
+            name: "foo",
+          },
+        },
+      ],
+    },
+  },
+  {
+    name: "loaders: single loader defined by string",
+    from: {
+      test: "foo",
+      loaders: [
+        "foo-loader?phenomic=awesome",
+      ],
+    },
+    to: {
+      test: "foo",
+      loaders: [ {
+        loader: "foo-loader",
+        query: {
+          phenomic: "awesome",
+        },
+      } ],
+    },
+  },
+  {
+    name: "loaders: multiple loaders defined by string and object",
+    from: {
+      test: "foo",
+      loaders: [
+        "foo-loader?phenomic=awesome",
+        {
+          loader: "bar-loader",
+        },
+        {
+          loader: "baz-loader",
+          query: {
+            phenomic: "awesome",
+          },
+        },
+      ],
+    },
+    to: {
+      test: "foo",
+      loaders: [
+        {
+          loader: "foo-loader",
+          query: {
+            phenomic: "awesome",
+          },
+        },
+        {
+          loader: "bar-loader",
+        },
+        {
+          loader: "baz-loader",
+          query: {
+            phenomic: "awesome",
+          },
+        },
+      ],
+    },
+  },
+]
+
+test("convert to normalized webpack 2 format", (t) => {
+  scenarios.forEach((scenario) => {
+    t.deepEqual(converter(scenario.from), scenario.to, scenario.name)
+  })
+})

--- a/src/_utils/edit-webpack-loader-config/__tests__/index.js
+++ b/src/_utils/edit-webpack-loader-config/__tests__/index.js
@@ -1,0 +1,191 @@
+import test from "ava"
+import { test as editor } from "../"
+
+const scenarios = [
+  {
+    name: "1 file type, 1 loader, `loader`",
+    from: [ {
+      test: "foo",
+      loader: "foo-loader?current=value",
+    } ],
+    loaderName: "foo-loader",
+    queryEdition: {
+      current: "newValue",
+      new: "value",
+    },
+    to: [ {
+      test: "foo",
+      loaders: [ "foo-loader?current=newValue&new=value" ],
+    } ],
+  },
+  {
+    name: "1 file type, multi loaders, `loader`",
+    from: [ {
+      test: "foo",
+      loader: "foo-loader?current=value!bar-loader",
+    } ],
+    loaderName: "foo-loader",
+    queryEdition: {
+      current: "newValue",
+      new: "value",
+    },
+    to: [ {
+      test: "foo",
+      loaders: [
+        "foo-loader?current=newValue&new=value",
+        "bar-loader",
+      ],
+    } ],
+  },
+  {
+    name: "multi file types, 1 loaders, `loader`",
+    from: [
+      {
+        test: "foo",
+        loader: "foo-loader?current=value!bar-loader",
+      },
+      {
+        test: "baz",
+        loader: "baz-loader",
+      },
+    ],
+    loaderName: "foo-loader",
+    queryEdition: {
+      current: "newValue",
+      new: "value",
+    },
+    to: [
+      {
+        test: "foo",
+        loaders: [
+          "foo-loader?current=newValue&new=value",
+          "bar-loader",
+        ],
+      },
+      {
+        test: "baz",
+        loaders: [ "baz-loader" ],
+      },
+    ],
+  },
+  {
+    name: "WP2: 1 file type, 1 loader, `loaders`",
+    from: [ {
+      test: "foo",
+      loaders: [
+        {
+          loader: "foo-loader",
+          query: {
+            current: "value",
+          },
+        },
+      ],
+    } ],
+    loaderName: "foo-loader",
+    queryEdition: {
+      current: "newValue",
+      new: "value",
+    },
+    webpack2: true,
+    to: [ {
+      test: "foo",
+      loaders: [
+        {
+          loader: "foo-loader",
+          query: {
+            current: "newValue",
+            new: "value",
+          },
+        },
+      ],
+    } ],
+  },
+  {
+    name: "WP2: 1 file type, multi loaders, `loaders`",
+    from: [ {
+      test: "foo",
+      loaders: [
+        {
+          loader: "foo-loader",
+          query: {
+            current: "value",
+          },
+        },
+        "bar-loader",
+      ],
+    } ],
+    loaderName: "foo-loader",
+    queryEdition: {
+      current: "newValue",
+      new: "value",
+    },
+    webpack2: true,
+    to: [ {
+      test: "foo",
+      loaders: [
+        {
+          loader: "foo-loader",
+          query: {
+            current: "newValue",
+            new: "value",
+          },
+        },
+        {
+          loader: "bar-loader",
+        },
+      ],
+    } ],
+  },
+]
+
+const shortLoadersNamescenarios = [
+  {
+    name: "short loader name in config",
+    from: [ {
+      test: "foo",
+      loader: "foo?current=value",
+    } ],
+    loaderName: "foo-loader",
+    queryEdition: { current: "newValue" },
+    to: [ {
+      test: "foo",
+      loaders: [ "foo?current=newValue" ],
+    } ],
+  },
+  {
+    name: "short loader name in function argument",
+    from: [ {
+      test: "foo",
+      loader: "foo-loader?current=value",
+    } ],
+    loaderName: "foo",
+    queryEdition: { current: "newValue" },
+    to: [ {
+      test: "foo",
+      loaders: [ "foo-loader?current=newValue" ],
+    } ],
+  },
+]
+
+const testScenarios = (scenarios, t) => {
+  scenarios.forEach((scenario) => {
+    t.deepEqual(
+      editor(
+        scenario.from,
+        scenario.loaderName,
+        scenario.queryEdition,
+        scenario.webpack2
+      ),
+      scenario.to,
+      scenario.name,
+    )
+  })
+}
+
+test("edit or add query for loader", (t) => {
+  testScenarios(shortLoadersNamescenarios, t)
+})
+
+test("support for short loader name", (t) => {
+  testScenarios(scenarios, t)
+})

--- a/src/_utils/edit-webpack-loader-config/convert-to-webpack-1.js
+++ b/src/_utils/edit-webpack-loader-config/convert-to-webpack-1.js
@@ -1,0 +1,29 @@
+import { stringify } from "querystring"
+
+import type {
+  fileType,
+  fileTypeWebpack2,
+} from "./define-loader.flow.js"
+
+/*
+ * Convert loader object from webpack 2 format to webpack 1
+ * NOTE: This must be run after the config was formated convert-to-webpack-2.js
+ */
+const convertToWebpack1 = (
+  fileType: fileTypeWebpack2
+): fileType => {
+  const loaders = fileType.loaders.map((loader) => {
+    if (!loader.hasOwnProperty("query")) {
+      return loader.loader
+    }
+
+    return loader.loader + "?" + stringify(loader.query)
+  })
+
+  return {
+    ...fileType,
+    loaders,
+  }
+}
+
+export default convertToWebpack1

--- a/src/_utils/edit-webpack-loader-config/convert-to-webpack-2.js
+++ b/src/_utils/edit-webpack-loader-config/convert-to-webpack-2.js
@@ -1,0 +1,63 @@
+import { parseQuery } from "loader-utils"
+
+import type {
+  fileType,
+  fileTypeWebpack2,
+  loaderDefWebpack2,
+} from "./define-loader.flow.js"
+
+/*
+ * Normalize loader config to Webpack 2 format
+ */
+const convertToWebpack2 = (
+  fileType: fileType
+): fileTypeWebpack2 => {
+  if (fileType.hasOwnProperty("loader")) {
+    const { loader, ...others } = fileType
+
+    const loaders = loader.split("!")
+      .map((loader) => parseLoaderString(loader))
+
+    return {
+      ...others,
+      loaders,
+    }
+  }
+
+  if (fileType.hasOwnProperty("loaders")) {
+    const loaders = fileType.loaders.map((loader) => {
+      if (typeof loader === "string") {
+        return parseLoaderString(loader)
+      }
+      return loader
+    })
+
+    return {
+      ...fileType,
+      loaders,
+    }
+  }
+
+  return fileType
+}
+
+const parseLoaderString = (loaderString: string): loaderDefWebpack2 => {
+  const pos = loaderString.indexOf("?")
+  // This loader doesn't have query
+  if (pos <= -1) {
+    return {
+      loader: loaderString,
+    }
+  }
+
+  // parse query string here
+  const name = loaderString.substr(0, pos)
+  const queryString = loaderString.slice(pos)
+
+  return {
+    loader: name,
+    query: parseQuery(queryString),
+  }
+}
+
+export default convertToWebpack2

--- a/src/_utils/edit-webpack-loader-config/define-loader.flow.js
+++ b/src/_utils/edit-webpack-loader-config/define-loader.flow.js
@@ -1,0 +1,15 @@
+export type fileType = {
+  test?: any,
+  loader?: string,
+  loaders?: Array<string>,
+}
+
+export type fileTypeWebpack2 = {
+  test?: any,
+  loaders: Array<loaderDefWebpack2 | string>,
+}
+
+export type loaderDefWebpack2 = {
+  loader: string,
+  query?: Object,
+}

--- a/src/_utils/edit-webpack-loader-config/index.js
+++ b/src/_utils/edit-webpack-loader-config/index.js
@@ -1,0 +1,84 @@
+// @flow
+import convertToWebpack2 from "./convert-to-webpack-2"
+import convertToWebpack1 from "./convert-to-webpack-1"
+
+// TODO: Handle if one loader is used multiple times
+
+const editWebpackLoaderConfig = (
+  config: WebpackConfig,
+  loaderName: string,
+  queryEdition: Object,
+  isThisWebpack2: bool = false
+): WebpackConfig => {
+  if (
+    config.module.hasOwnProperty("loader") &&
+    !Array.isArray(config.module.loaders)
+  ) {
+    throw new Error("config parameter must be a valid webpack config")
+  }
+
+  const fileTypes = config.module.loaders
+    .map((fileType) => convertToWebpack2(fileType))
+    .map((fileType) => {
+      const loaders = fileType.loaders
+        .map((loader) => {
+          const currentLoaderName = loader.loader
+          // Yeah, this is the loader that we are looking for
+          if (
+            currentLoaderName === loaderName ||
+            currentLoaderName === loaderName.replace("-loader", "") ||
+            currentLoaderName === loaderName + "-loader"
+          ) {
+            return {
+              ...loader,
+              query: {
+                ...loader.query,
+                ...queryEdition,
+              },
+            }
+          }
+
+          return loader
+        })
+
+      return {
+        ...fileType,
+        loaders,
+      }
+    })
+
+  // Return edited webpack fileTypes format
+  if (isThisWebpack2) {
+    return {
+      ...config,
+      module: {
+        ...config.module,
+        loaders: fileTypes,
+      },
+    }
+  }
+  // convert fileTypes back to webpack 1 format and return
+  else {
+    return {
+      ...config,
+      module: {
+        ...config.module,
+        loaders: fileTypes.map((fileType) => convertToWebpack1(fileType)),
+      },
+    }
+  }
+
+}
+
+export default editWebpackLoaderConfig
+
+export const test = (
+  config: Array<Object>,
+  ...args: Array<any>
+): WebpackConfig => (
+  editWebpackLoaderConfig({
+    module: {
+      loaders: config,
+    },
+  }, ...args).module.loaders
+)

--- a/src/builder/webpack/config.common.js
+++ b/src/builder/webpack/config.common.js
@@ -3,6 +3,8 @@
 import { DefinePlugin } from "webpack"
 import url from "url"
 import pkg from "../../../package.json"
+import editWebpackLoaderConfig from "../../_utils/edit-webpack-loader-config"
+import findCacheDir from "find-cache-dir"
 import {
   getCacheDir,
   hardSourceRecordsPath,
@@ -18,7 +20,7 @@ export default (config: PhenomicConfig): WebpackConfig => {
   const cacheDir = getCacheDir(config)
   const { webpackConfig = {} } = config
 
-  return {
+  let finalConfig = {
     ...webpackConfig,
     ...config.webpackHardCache && hardSourceRecordsPath(cacheDir),
     plugins: [
@@ -41,4 +43,18 @@ export default (config: PhenomicConfig): WebpackConfig => {
       } }),
     ],
   }
+
+  // Adjust babel-loader cacheDirectory configuration
+  // To avoid a bunch of .json.gz files generated in process.cwd()
+  // When running as root user
+  // See https://github.com/MoOx/phenomic/issues/545
+  finalConfig = editWebpackLoaderConfig(
+    finalConfig,
+    "babel-loader",
+    {
+      cacheDirectory: findCacheDir({ name: "phenomic/babel-loader" }),
+    }
+  )
+
+  return finalConfig
 }


### PR DESCRIPTION
As we have plan to switch to Jest so I wrote tests that doesn't depend on test runner. They looks cleaner right? 

Also, [the new webpack loader configuration doesn't work](https://gist.github.com/sokra/27b24881210b56bbaff7#loaders-configuration). I tried it in docs and webpack throw errors.  

The gist of edit-webpack-loader-config

Convert all config to webpack 2 `loaders` style. Do the manipulation. Convert it back to webpack 1 `loaders` style if needed.