### PR TITLE
Set npm loglevel to error on Travis and Appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ before_install:
   - NPM_VERSION=$(npm --version)
   - 'if [ "${NPM_VERSION:0:2}" = "2." ]; then npm i -g npm@latest; fi'
   # faster npm install
-  - npm set progress=false
+  - npm set progress false
+  - npm set loglevel error
   # remove useless/non listed deps
   - npm prune
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,8 @@ cache:
 
 install:
   - ps: Install-Product node $env:nodejs_version x64
-  - npm set progress=false
+  - npm set progress false
+  - npm set loglevel error
   - npm prune
   - npm install
 


### PR DESCRIPTION
I'm tried of scrolling pass npm warnings to get to the interesting part on CI's log. So I sent this PR to not to do it again. 

By the way, 

![image](https://cloud.githubusercontent.com/assets/3049054/18608253/846fad36-7d0e-11e6-90ee-5c46c3251ed5.png)
