### PR TITLE
Remove markdown images from appearing in description text

### DIFF
--- a/src/loader-plugin-markdown-init-head.description-property-from-content/index.js
+++ b/src/loader-plugin-markdown-init-head.description-property-from-content/index.js
@@ -11,7 +11,9 @@ const defaultOpts = {
 
 function description(text, opts = {}) {
   opts = { ...defaultOpts, ...opts }
-
+  // remove image tags from markdown
+  text = text.replace(/\!\[.*?\)/g, '')
+  
   if (opts.pruneLength === 0) {
     console.warn(
       "You defined 'description.pruneLength' of phenomic loader " +
@@ -21,7 +23,7 @@ function description(text, opts = {}) {
 
     opts.pruneLength = defaultOpts.pruneLength
   }
-
+  
   return prune(
     remark()
       .use(stripMd)


### PR DESCRIPTION
Markdown images and italics and stuff are showing up as plain text in the collection description.

![image](https://cloud.githubusercontent.com/assets/532272/18819190/3166966c-8340-11e6-80f4-e6169b3e3ce5.png)

![image](https://cloud.githubusercontent.com/assets/532272/18819188/1989fc50-8340-11e6-961a-11e255bd7116.png)

These regex added removes markdown images from text before it's processed
