### PR TITLE
Keep query string and hash on fixed URL

### DIFF
--- a/src/components/PageContainer/component.js
+++ b/src/components/PageContainer/component.js
@@ -64,17 +64,15 @@ function getBase(location: Object): string {
 
 function adjustCurrentUrl(location: Object, item: Object, props: Props): void {
   // adjust url (eg: missing trailing slash)
-  const currentExactPageUrl = location.href
-    .replace(getBase(location), "/")
-    .replace(location.hash, "")
-
-  if (currentExactPageUrl !== item.__url) {
+  const currentExactPageUrl = location.href.replace(getBase(location), "/")
+  const itemURL = item.__url + location.search + location.hash
+  if (currentExactPageUrl !== itemURL) {
     props.logger.info(
       "phenomic: PageContainer: " +
-      `replacing by '${ currentExactPageUrl }' to '${ item.__url }'`
+      `replacing by '${ currentExactPageUrl }' to '${ itemURL }'`
     )
     if (browserHistory) {
-      browserHistory.replace(item.__url)
+      browserHistory.replace(itemURL)
     }
   }
 }


### PR DESCRIPTION
Before: `http://localhost:3333/partners?jhjajhdsa=yo#lol` automatically removes query + hash -> `http://localhost:3333/partners/`

After: URL is fixed (trailing slash added) and query string + hash left in place  `http://localhost:3333/partners?jhjajhdsa=yo#lol`

This makes it possible for links with hashes to retain hashes.

It also makes it possible for us to use query params in our site. EG `utm` tracking for marketing