### PR TITLE
Fix commented out example for global CSS to be valid JS syntax

### DIFF
--- a/themes/phenomic-theme-base/webpack.config.babel.js
+++ b/themes/phenomic-theme-base/webpack.config.babel.js
@@ -160,12 +160,12 @@ export default (config = {}) => {
         //   // for your own CSS. If so, uncomment the line below
         //   // include: path.resolve(__dirname, "node_modules"),
         //   loader: ExtractTextPlugin.extract({
-        //     "fallbackLoader": "style-loader",
-        //     "loader": [
+        //     fallbackLoader: "style-loader",
+        //     loader: [
         //       "css-loader",
         //       {
-        //         "loader": "postcss-loader",
-        //         "query": { "plugins": postcssPlugins },
+        //         loader: "postcss-loader",
+        //         query: { "plugins": postcssPlugins },
         //       },
         //     ]
         //   }),

--- a/themes/phenomic-theme-base/webpack.config.babel.js
+++ b/themes/phenomic-theme-base/webpack.config.babel.js
@@ -159,15 +159,16 @@ export default (config = {}) => {
         //   // for global CSS if you want to keep CSS Modules by default
         //   // for your own CSS. If so, uncomment the line below
         //   // include: path.resolve(__dirname, "node_modules"),
-        //   loader: ExtractTextPlugin.extract(
-        //     fallbackLoader: "style-loader",
-        //     loader: [
-        //      "css-loader",
-        //      {
-        //        loader: "postcss-loader",
-        //        query: { plugins: postcssPlugins },
-        //      },
-        //   ),
+        //   loader: ExtractTextPlugin.extract({
+        //     "fallbackLoader": "style-loader",
+        //     "loader": [
+        //       "css-loader",
+        //       {
+        //         "loader": "postcss-loader",
+        //         "query": { "plugins": postcssPlugins },
+        //       },
+        //     ]
+        //   }),
         // },
         // ! \\ if you want to use Sass or LESS, you can add sass-loader or
         // less-loader after postcss-loader (or replacing it).


### PR DESCRIPTION
Noticed that when trying to use this commented out code sample that it wasn't fully valid JS. I also noticed that it's using Webpack2 syntax, so if you'd like I can add that note in there too (since it seemed that most Webpack2 specific stuff was commented that way).