### PR TITLE
keep URL params

### DIFF
--- a/src/components/PageContainer/__tests__/component.with-spy.js
+++ b/src/components/PageContainer/__tests__/component.with-spy.js
@@ -181,6 +181,44 @@ test("should redirect if url doesn't match needed", (t) => {
   )
 })
 
+test("should redirect and keep url parameters", (t) => {
+  const spy = sinon.spy()
+  console.info = spy
+
+  process.env.PHENOMIC_USER_PATHNAME = "/"
+  dom("http://localhost/foo?test=yes")
+
+  const PageContainer = require("../component").default
+  const renderer = createRenderer()
+  renderer.render(
+    jsx(
+      PageContainer,
+      {
+        params: { splat: "foo/" },
+        pages: { "/foo/": {} },
+        getPage: noop,
+        setPageNotFound: noop,
+        layouts: { Page },
+      }
+    ),
+    {
+      collection: [ {
+        __url: "/foo/",
+      } ],
+    },
+  )
+  t.true(
+    spy.calledWithMatch(
+      // replacing by '/foo?test=yes' to '/foo/?test=yes'
+      /replacing by \'\/foo\?test=yes\' to \'\/foo\/\?test=yes\'/
+    )
+  )
+  t.is(
+    window.location.href,
+    "http://localhost/foo/?test=yes"
+  )
+})
+
 test("should NOT redirect if url contains hash", (t) => {
   process.env.PHENOMIC_USER_PATHNAME = "/"
   dom("http://localhost/foo/#some-hash")

--- a/src/components/PageContainer/component.js
+++ b/src/components/PageContainer/component.js
@@ -64,17 +64,16 @@ function getBase(location: Object): string {
 
 function adjustCurrentUrl(location: Object, item: Object, props: Props): void {
   // adjust url (eg: missing trailing slash)
-  const currentExactPageUrl = location.href
-    .replace(getBase(location), "/")
-    .replace(location.hash, "")
+  const currentExactPageUrl = location.href.replace(getBase(location), "/")
+  const itemURL = item.__url + location.search + location.hash
 
-  if (currentExactPageUrl !== item.__url) {
+  if (currentExactPageUrl !== itemURL) {
     props.logger.info(
       "phenomic: PageContainer: " +
-      `replacing by '${ currentExactPageUrl }' to '${ item.__url }'`
+      `replacing by '${ currentExactPageUrl }' to '${ itemURL }'`
     )
     if (browserHistory) {
-      browserHistory.replace(item.__url)
+      browserHistory.replace(itemURL)
     }
   }
 }


### PR DESCRIPTION
Before: http://localhost:3333/partners?jhjajhdsa=yo#lol automatically removes query + hash -> http://localhost:3333/partners/

After: URL is fixed (trailing slash added) and query string + hash left in place http://localhost:3333/partners?jhjajhdsa=yo#lol

This makes it possible for links with hashes to retain hashes.

It also makes it possible for us to use query params in our site. EG utm tracking for marketing