### PR TITLE
Suggest adding sass/less-loader BEFORE postcss-loader

### DIFF
--- a/themes/phenomic-theme-base/webpack.config.babel.js
+++ b/themes/phenomic-theme-base/webpack.config.babel.js
@@ -191,7 +191,7 @@ export default (config = {}) => {
         },
         */
         // ! \\ if you want to use Sass or LESS, you can add sass-loader or
-        // less-loader after postcss-loader (or replacing it).
+        // less-loader before (for CSS linting to keep working) postcss-loader (or replacing it).
         // ! \\ You will also need to adjust the file extension
         // and to run the following command
         //


### PR DESCRIPTION
CSS linting takes place when postcss-loader is parsing the CSS. SASS/LESS parsers change the output so in order to keep CSS linting actual source files, postcss-loader should be run first, thus it should be in the end of loaders array as webpack runs loaders from right to left.
Hope that makes sense.