### PR TITLE
Handle .markdown files

### DIFF
--- a/docs/content/docs/usage/configuration/build.md
+++ b/docs/content/docs/usage/configuration/build.md
@@ -49,7 +49,7 @@ export const makeConfig = (config = {}) => {
     module: {
       loaders: [
         {
-          test: /\.md$/,
+          test: /\.(md|markdown)$/,
           loader: phenomicLoader,
 
           // you can also define options here, but functions will be silently

--- a/docs/content/docs/usage/feeds.md
+++ b/docs/content/docs/usage/feeds.md
@@ -23,7 +23,7 @@ import PhenomicLoaderFeedWebpackPlugin
     // webpack 2
     // rules: [
       {
-        test: /\.md$/,
+        test: /\.(md|markdown)$/,
         loader: phenomicLoader,
         query: {
           context: path.join(config.cwd, config.source),

--- a/docs/content/docs/usage/plugins.md
+++ b/docs/content/docs/usage/plugins.md
@@ -158,7 +158,7 @@ import { phenomicLoader } from "phenomic"
    // webpack 2
    // rules: [
      {
-       test: /\.md$/,
+       test: /\.(md|markdown)$/,
        loader: phenomicLoader,
        query: {
           context: path.join(config.cwd, config.source),

--- a/docs/scripts/phenomic.browser.js
+++ b/docs/scripts/phenomic.browser.js
@@ -11,7 +11,7 @@ import phenomicClient from "phenomic/lib/client"
 phenomicClient({ metadata, routes, store })
 
 // md files processed via phenomic-loader to JSON & generate collection
-let mdContext = require.context("../content", true, /\.md$/)
+let mdContext = require.context("../content", true, /\.(md|markdown)$/)
 mdContext.keys().forEach(mdContext)
 
 // hot loading
@@ -19,7 +19,7 @@ if (module.hot) {
 
   // hot load md
   module.hot.accept(mdContext.id, () => {
-    mdContext = require.context("../content", true, /\.md$/)
+    mdContext = require.context("../content", true, /\.(md|markdown)$/)
     const mdHotUpdater = require("phenomic/lib/client/hot-md").default
     const requireUpdate = mdHotUpdater(mdContext, window.__COLLECTION__, store)
     mdContext.keys().forEach(requireUpdate)

--- a/docs/webpack.config.babel.js
+++ b/docs/webpack.config.babel.js
@@ -32,7 +32,7 @@ export default (config = {}) => {
       [webpackVersion() === 1 ? "loaders" : "rules"]: [
         {
           // phenomic requirement
-          test: /\.md$/,
+          test: /\.(md|markdown)$/,
           loader: phenomicLoader,
           ...(
             webpackVersion() === 1

--- a/src/_utils/urlify/__tests__/index.js
+++ b/src/_utils/urlify/__tests__/index.js
@@ -51,6 +51,46 @@ test(
 )
 
 test(
+  "should transform */index.markdown path to a simple url",
+  (t) => t.is(
+    urlify("something/index.markdown"),
+    "something/"
+  )
+)
+
+test(
+  "should transform *\\index.markdown path to a simple url (windows compat)",
+  (t) => t.is(
+    urlify("something\\index.markdown"),
+    "something/"
+  )
+)
+
+test(
+  "should transform md path to a simple url",
+  (t) => t.is(
+    urlify("something-else.markdown"),
+    "something-else/"
+  )
+)
+
+test(
+  "should transform index.markdown path to a empty url",
+  (t) => t.is(
+    urlify("index.markdown"),
+    ""
+  )
+)
+
+test(
+  "should transform index.markdown path to a empty url (with root)",
+  (t) => t.is(
+    urlify("/index.markdown"),
+    "/"
+  )
+)
+
+test(
   "should handle windows backslash",
   (t) => t.is(
     urlify("some\\thing\\else\\"),

--- a/src/_utils/urlify/index.js
+++ b/src/_utils/urlify/index.js
@@ -17,9 +17,11 @@ export default function urlify(
 
   url = url
     // something/index.md => something
-    .replace(/\bindex\.md$/, "")
+    // something/index.markdown => something
+    .replace(/\bindex\.(md|markdown)$/, "")
     // something-else.md => something-else
-    .replace(/\.md$/, "")
+    // something-else.markdown => something-else
+    .replace(/\.(md|markdown)$/, "")
 
   // if url is not and html file, we will tweak it a little bit depending on the
   // length wanted (full url or folder url)

--- a/src/loader-feed-webpack-plugin/__tests__/fixtures/script.js
+++ b/src/loader-feed-webpack-plugin/__tests__/fixtures/script.js
@@ -1,1 +1,1 @@
-require.context(".", true, /\.md$/)
+require.context(".", true, /\.(md|markdown)$/)

--- a/src/loader-feed-webpack-plugin/__tests__/index.js
+++ b/src/loader-feed-webpack-plugin/__tests__/index.js
@@ -16,7 +16,7 @@ test.cb("loader feed webpack plugin", (t) => {
       module: {
         [webpackVersion() === 1 ? "loaders" : "rules"]: [
           {
-            test: /\.md$/,
+            test: /\.(md|markdown)$/,
             loader: __dirname + "/../../loader/index.js",
             exclude: /node_modules/,
           },

--- a/src/loader/__tests__/fixtures/script.js
+++ b/src/loader/__tests__/fixtures/script.js
@@ -1,1 +1,1 @@
-require.context(".", true, /\.md$/)
+require.context(".", true, /\.(md|markdown)$/)

--- a/src/loader/__tests__/index.js
+++ b/src/loader/__tests__/index.js
@@ -15,7 +15,7 @@ test.cb("phenomic loader", (t) => {
       module: {
         [webpackVersion() === 1 ? "loaders" : "rules"]: [
           {
-            test: /\.md$/,
+            test: /\.(md|markdown)$/,
             loader: __dirname + "/../index.js",
             exclude: /node_modules/,
           },
@@ -119,7 +119,7 @@ test.cb("phenomic loader can be used with plugins", (t) => {
       module: {
         [webpackVersion() === 1 ? "loaders" : "rules"]: [
           {
-            test: /\.md$/,
+            test: /\.(md|markdown)$/,
             loader: __dirname + "/../index.js",
             exclude: /node_modules/,
             ...(

--- a/themes/phenomic-theme-base/scripts/phenomic.browser.js
+++ b/themes/phenomic-theme-base/scripts/phenomic.browser.js
@@ -11,7 +11,7 @@ import phenomicClient from "phenomic/lib/client"
 phenomicClient({ metadata, routes, store })
 
 // md files processed via phenomic-loader to JSON & generate collection
-let mdContext = require.context("../content", true, /\.md$/)
+let mdContext = require.context("../content", true, /\.(md|markdown)$/)
 mdContext.keys().forEach(mdContext)
 
 // hot loading
@@ -19,7 +19,7 @@ if (module.hot) {
 
   // hot load md
   module.hot.accept(mdContext.id, () => {
-    mdContext = require.context("../content", true, /\.md$/)
+    mdContext = require.context("../content", true, /\.(md|markdown)$/)
     const mdHotUpdater = require("phenomic/lib/client/hot-md").default
     const requireUpdate = mdHotUpdater(mdContext, window.__COLLECTION__, store)
     mdContext.keys().forEach(requireUpdate)

--- a/themes/phenomic-theme-base/webpack.config.babel.js
+++ b/themes/phenomic-theme-base/webpack.config.babel.js
@@ -44,7 +44,7 @@ export default (config = {}) => {
         // allow to generate collection and rss feed.
         {
           // phenomic requirement
-          test: /\.md$/,
+          test: /\.(md|markdown)$/,
           loader: phenomicLoader,
           query: {
             context: path.join(__dirname, config.source),


### PR DESCRIPTION
When I tried to use `SiteLeaf` I faced to a problem. `SiteLeaf` generates `.markdown` files instead of `.md` files.

So This PR fix that