### PR TITLE
Add new stylelint rule

### DIFF
--- a/src/stylelint-config-recommended/index.js
+++ b/src/stylelint-config-recommended/index.js
@@ -1,0 +1,15 @@
+// @flow
+
+module.exports = {
+  "extends": "stylelint-config-standard",
+  "rules": {
+    "property-no-unknown": [
+      true,
+      {
+        "ignoreProperties": [
+          "composes",
+        ],
+      },
+    ],
+  },
+}

--- a/themes/phenomic-theme-base/package.json
+++ b/themes/phenomic-theme-base/package.json
@@ -85,7 +85,17 @@
     "extends": "./node_modules/phenomic/lib/eslint-config-recommended/index.js"
   },
   "stylelint": {
-    "extends": "stylelint-config-standard"
+    "extends": "stylelint-config-standard",
+    "rules": {
+      "property-no-unknown": [
+        true,
+        {
+          "ignoreProperties": [
+            "composes"
+          ]
+        }
+      ]
+    }
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",

--- a/themes/phenomic-theme-base/package.json
+++ b/themes/phenomic-theme-base/package.json
@@ -85,17 +85,7 @@
     "extends": "./node_modules/phenomic/lib/eslint-config-recommended/index.js"
   },
   "stylelint": {
-    "extends": "stylelint-config-standard",
-    "rules": {
-      "property-no-unknown": [
-        true,
-        {
-          "ignoreProperties": [
-            "composes"
-          ]
-        }
-      ]
-    }
+    "extends": "./node_modules/phenomic/lib/stylelint-config-recommended/index.js"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",


### PR DESCRIPTION
`css-modules` are enabled by the default `webpack` configuration. 

 The `composes` rule is very usefull to compose selectors. I think it could be great to enable it directly as a `stylelint` rule
