### PR TITLE
DX improvement: Reuse tab if one is already open

### DIFF
--- a/src/builder/openChrome.applescript
+++ b/src/builder/openChrome.applescript
@@ -1,10 +1,5 @@
 (*
-Copyright (c) 2015-present, Facebook, Inc.
-All rights reserved.
-
-This source code is licensed under the BSD-style license found in the
--- LICENSE file in the root directory of this source tree. An additional grant
-of patent rights can be found in the PATENTS file in the same directory.
+Ripped from https://gist.github.com/mayoff/1138816
 *)
 
 on run argv
@@ -23,8 +18,9 @@ on run argv
       set theTabIndex to 0
       repeat with theTab in every tab of theWindow
         set theTabIndex to theTabIndex + 1
+        # found url from the same path, not only exact urls
+        # if theTab's URL is theURL then
         if theTab's URL contains theURL then
-        #if theTab's URL is theURL then
           set found to true
           exit repeat
         end if

--- a/src/builder/openChrome.applescript
+++ b/src/builder/openChrome.applescript
@@ -1,0 +1,49 @@
+(*
+Copyright (c) 2015-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+-- LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+*)
+
+on run argv
+  set theURL to item 1 of argv
+
+  tell application "Chrome"
+
+    if (count every window) = 0 then
+      make new window
+    end if
+
+    -- Find a tab currently running the debugger
+    set found to false
+    set theTabIndex to -1
+    repeat with theWindow in every window
+      set theTabIndex to 0
+      repeat with theTab in every tab of theWindow
+        set theTabIndex to theTabIndex + 1
+        if theTab's URL contains theURL then
+        #if theTab's URL is theURL then
+          set found to true
+          exit repeat
+        end if
+      end repeat
+
+      if found then
+        exit repeat
+      end if
+    end repeat
+
+    if found then
+      tell theTab to reload
+      set index of theWindow to 1
+      set theWindow's active tab index to theTabIndex
+    else
+      tell window 1
+        activate
+        make new tab with properties {URL:theURL}
+      end tell
+    end if
+  end tell
+end run

--- a/src/builder/server.js
+++ b/src/builder/server.js
@@ -190,12 +190,14 @@ export default (config) => {
     if (port !== devPort) {
       log(`Port ${ devPort } is not available. Using port ${ port } instead.`)
     }
+
     server.listen(port, devHost, (err) => {
       if (err) {
         throw err
       }
       const href = `http://${ devHost }:${ port }${ config.baseUrl.pathname }`
       log(`Development server listening on ${ href }`)
+
       if (config.open) {
         const openUrl = href.replace(devHost, "localhost")
         if (process.platform === "darwin") {
@@ -215,15 +217,7 @@ export default (config) => {
         }
         // Fallback to opn
         // (It will always open new tab)
-        try {
-          opn(openUrl)
-          .catch(() => {}) // Prevent `unhandledRejection` error.
-          return true
-        }
-        catch (err) {
-          return false
-        }
-
+        opn(openUrl)
       }
     })
   })


### PR DESCRIPTION
Snagged from https://github.com/facebookincubator/create-react-app/blob/0bd593baa777606ffb72f63eab9f5fd491062007/packages/react-dev-utils/openBrowser.js

This reuses the same browser tab if one is already open instead of reopening a new tab each time `phenomic start` runs.

For OSX only but it defaults back to `opn` package if person on linux/windows.

Lots of tabs getting opened was getting annoying and would sometimes cause funky stuff to happen with hot module reloading
