### PR TITLE
Removed: webpack build notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "valid-url": "^1.0.9",
     "webpack-dev-middleware": "^1.6.1",
     "webpack-hot-middleware": "^2.12.2",
-    "webpack-notifier": "^1.4.0",
     "webpack-sources": "^0.1.2",
     "yargs": "^4.3.1"
   },

--- a/src/builder/server.js
+++ b/src/builder/server.js
@@ -6,7 +6,6 @@ import webpack from "webpack"
 import webpackDevMiddleware from "webpack-dev-middleware"
 import webpackHotMiddleware from "webpack-hot-middleware"
 import historyFallbackMiddleware from "connect-history-api-fallback"
-import WebpackNotifierPlugin from "webpack-notifier"
 import portFinder from "portfinder"
 import opn from "opn"
 
@@ -69,8 +68,6 @@ export default (config) => {
         ),
         new webpack.HotModuleReplacementPlugin(),
         new webpack.NoErrorsPlugin(),
-
-        new WebpackNotifierPlugin(),
       ],
     }
 


### PR DESCRIPTION
If you want to add notifications back, please directly use
[webpack-notifier](https://www.npmjs.com/package/webpack-notifier)

Closes #859