### PR TITLE
Don't intercept clicks on links with no href

### DIFF
--- a/src/_utils/catch-links/index.js
+++ b/src/_utils/catch-links/index.js
@@ -25,7 +25,7 @@ const catchLinks = (cb) => (ev: any): void => {
   const href = anchor.getAttribute("href")
 
   // Don't intercerpt anchor
-  if (href.startsWith("#")) {
+  if (!href || href.startsWith("#")) {
     return
   }
 


### PR DESCRIPTION
It's possible to have an anchor tag without an `href` attribute, and this code would have thrown an exception in that case.