### PR TITLE
Prevent duplicate loading of JS files

### DIFF
--- a/src/components/Html/__tests__/__snapshots__/aphrodite.js.snap
+++ b/src/components/Html/__tests__/__snapshots__/aphrodite.js.snap
@@ -23,6 +23,13 @@ exports[`test should render Html component with aphrodite styles when possible 1
     <link
       href="test.css"
       rel="stylesheet" />
+    <script
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "window._aphrodite = [\"stuff\"]);",
+        }
+      }
+      data-react-helmet={true} />
   </head>
   <body>
     <div
@@ -34,13 +41,6 @@ exports[`test should render Html component with aphrodite styles when possible 1
       id="phenomic" />
     <script
       phenomicStuff={true} />
-    <script
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "window._aphrodite = [\"stuff\"]);",
-        }
-      }
-      data-react-helmet={true} />
     <script
       src="test.js" />
   </body>

--- a/src/components/Html/__tests__/__snapshots__/glamor.js.snap
+++ b/src/components/Html/__tests__/__snapshots__/glamor.js.snap
@@ -22,6 +22,13 @@ exports[`test should render Html component with glamor styles when possible 1`] 
     <link
       href="test.css"
       rel="stylesheet" />
+    <script
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "window._glamor = [{\"id\":\"s\"}]",
+        }
+      }
+      data-react-helmet={true} />
   </head>
   <body>
     <div
@@ -33,13 +40,6 @@ exports[`test should render Html component with glamor styles when possible 1`] 
       id="phenomic" />
     <script
       phenomicStuff={true} />
-    <script
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "window._glamor = [{\"id\":\"s\"}]",
-        }
-      }
-      data-react-helmet={true} />
     <script
       src="test.js" />
   </body>

--- a/src/components/Html/index.js
+++ b/src/components/Html/index.js
@@ -100,11 +100,11 @@ const Html = (props: Props) => {
             <link key={ "phenomic.css." + i } rel="stylesheet" href={ file } />
           ))
         }
+        { head.script.toComponent() }
       </head>
       <body>
         <div id="phenomic" dangerouslySetInnerHTML={{ __html: body }} />
         { props.renderScript() }
-        { head.script.toComponent() }
         {
           props.js.map((file, i) => (
             <script key={ "phenomic.js." + i } src={ file } />

--- a/src/static/__tests__/url-as-html.js
+++ b/src/static/__tests__/url-as-html.js
@@ -193,6 +193,7 @@ test("custom script tags", async (t) => {
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <script data-react-helmet="true" src="http://foo.bar/baz.js"></script>
 </head>
 
 <body>
@@ -221,7 +222,6 @@ test("custom script tags", async (t) => {
       }
     }
   </script>
-  <script data-react-helmet="true" src="http://foo.bar/baz.js"></script>
   <script src="/test.js"></script>
 </body>
 


### PR DESCRIPTION
When doing a build react-helmet is loading js files once in the head and once in the body.  React helmet manages the head and thus this script toComponent() should be in the head.