### PR TITLE
Remove superfluous replace

### DIFF
--- a/src/loader-plugin-markdown-init-head.description-property-from-content/index.js
+++ b/src/loader-plugin-markdown-init-head.description-property-from-content/index.js
@@ -28,8 +28,7 @@ function description(text, opts = {}) {
       .use(stripMd)
       .process(text)
       .toString()
-      .replace(/\n+/g, "\n") // Replace multiple new lines with one
-      .replace(/\n/g, " ") // Avoid useless new lines
+      .replace(/\n+/g, " ") // Avoid useless new lines
       .trim()
     ,
     opts.pruneLength,


### PR DESCRIPTION
Probably I'm missing something, but `replace(/\n+/g, "\n").replace(/\n/g, " ")` is totally equivalent to `replace(/\n+/g, " ")`, isn't it?