### PR TITLE
Docs: typo in Getting Started route example (#938)

### DIFF
--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -80,7 +80,7 @@ My super **content**!
 ```
 
 Then your content will be accessible at
-[http://localhost:3333/my-super-url/](http://localhost:3333/my-super-url/)
+[http://localhost:3333/my-super-url/](http://localhost:3333/my-super-url.html)
 
 ---
 


### PR DESCRIPTION
the path is incorrect. needs the `.html` extension to work.