### PR TITLE
Wrap setup shell command variables in quotes

### DIFF
--- a/docs/content/docs/setup.md
+++ b/docs/content/docs/setup.md
@@ -26,13 +26,13 @@ we use html just to add contenteditable
 
 ```sh
 DIR=your-website-folder
-mkdir $DIR && cd $DIR && mkdir node_modules
+mkdir "$DIR" && cd "$DIR" && mkdir node_modules
 ```
 
 -->
 
 <pre contenteditable="true"><code class="hljs language-sh">DIR=your-website-folder
-mkdir <span class="hljs-variable">$DIR</span> &amp;&amp; <span class="hljs-built_in">cd</span> <span class="hljs-variable">$DIR</span> &amp;&amp; mkdir node_modules</code></pre>
+mkdir "<span class="hljs-variable">$DIR</span>" &amp;&amp; <span class="hljs-built_in">cd</span> "<span class="hljs-variable">$DIR</span>" &amp;&amp; mkdir node_modules</code></pre>
 
 Now we will be at the right place so we can grab Phenomic & launch the setup.
 Right after that, we will grab required dependencies & you are good to go!
@@ -94,7 +94,7 @@ That's an easy step.
 
 ```sh
 DIR=your-website-folder
-mkdir $DIR && cd $DIR
+mkdir "$DIR" && cd "$DIR"
 ```
 
 ### Get Phenomic


### PR DESCRIPTION
In the setup, it is advised to store the desired site directory in a variable for later use, then the variable is used later for setting up paths. This would break the command if the path contains any spaces and is generally considered bad practice. Quoting your shell variables when using them (especially when paths are concerned) is [highly][ref1][[1][ref1]] [recommended][ref2][[2][ref2]].

I can't remember if Windows acts the same.


\[1]: http://www.tldp.org/LDP/abs/html/quotingvar.html
\[2]: http://stackoverflow.com/questions/10067266/when-to-wrap-quotes-around-a-variable


[ref1]: http://www.tldp.org/LDP/abs/html/quotingvar.html
[ref2]: http://stackoverflow.com/questions/10067266/when-to-wrap-quotes-around-a-variable