### PR TITLE
Fix HRM hot reload for md files (#973)

### DIFF
--- a/src/client/hot-md.js
+++ b/src/client/hot-md.js
@@ -6,6 +6,9 @@ export default (mdContext, collection, store) => (file) => {
     (item) => item.__filename === file.slice("./".length)
   )
   const dataUrl = mdContext(file)
+  if (null == item){
+    return;
+  }
   if (dataUrl !== item.__dataUrl) {
     item.__dataUrl = dataUrl
     console.log(file, " hot update")


### PR DESCRIPTION
When making changes to md files I noticed that an HMR error would throw after the first change, and thereafter you would have to force reload the page in the browser to see updates. Added simple null check down in hot-md to prevent the error from throwing.

Tested locally and verified that hot reloads worked properly with md files.
