### PR TITLE
Path to phenomic fix for Windows

### DIFF
--- a/docs/content/docs/setup.md
+++ b/docs/content/docs/setup.md
@@ -70,13 +70,13 @@ mkdir %DIR% && cd %DIR% && mkdir node_modules
 Now we will be at the right place so we can grab Phenomic & launch the setup.
 Right after that, we will grab required dependencies & you are good to go!
 ```cmd
-npm install phenomic && .\node_modules\.bin\phenomic setup
+npm install phenomic && ./node_modules/.bin/phenomic setup
 npm install && npm start
 ```
 _or with `yarn`_
 
 ```cmd
-yarn add phenomic && .\node_modules\.bin\phenomic setup
+yarn add phenomic && ./node_modules/.bin/phenomic setup
 yarn install && yarn start
 ```
 


### PR DESCRIPTION
I might be wrong, but as I tried to do the setup on a Windows 10 machine I found out that the current paths aren't recognized by windows. I did the change I suggest and everything worked fine.