### PR TITLE
Base theme: use date-fns to parse post dates

### DIFF
--- a/themes/phenomic-theme-base/package.json
+++ b/themes/phenomic-theme-base/package.json
@@ -96,6 +96,7 @@
     "babel-preset-stage-2": "^6.22.0",
     "classnames": "^2.2.5",
     "css-loader": "^0.28.0",
+    "date-fns": "^1.28.2",
     "eslint": "^3.7.1",
     "eslint-loader": "^1.7.1",
     "eslint-plugin-react": "^6.4.0",

--- a/themes/phenomic-theme-base/src/components/PagePreview/index.js
+++ b/themes/phenomic-theme-base/src/components/PagePreview/index.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from "react"
+import parseDate from "date-fns/parse"
 import { Link } from "phenomic"
 
 import Button from "../../components/Button"
@@ -6,7 +7,7 @@ import Button from "../../components/Button"
 import styles from "./index.css"
 
 const PagePreview = ({ __url, title, date, description }) => {
-  const pageDate = date ? new Date(date) : null
+  const pageDate = date ? parseDate(date) : null
 
   return (
     <div className={ styles.wrapper }>

--- a/themes/phenomic-theme-base/src/layouts/Post/index.js
+++ b/themes/phenomic-theme-base/src/layouts/Post/index.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from "react"
+import parseDate from "date-fns/parse"
 
 import LatestPosts from "../../components/LatestPosts"
 import Page from "../Page"
@@ -7,7 +8,7 @@ import styles from "./index.css"
 
 const Post = (props) => {
   // it's up to you to choose what to do with this layout ;)
-  const pageDate = props.head.date ? new Date(props.head.date) : null
+  const pageDate = props.head.date ? parseDate(props.head.date) : null
 
   return (
     <Page

--- a/themes/phenomic-theme-base/yarn.lock
+++ b/themes/phenomic-theme-base/yarn.lock
@@ -1529,6 +1529,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+date-fns@^1.28.2:
+  version "1.28.2"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.2.tgz#19e4192d68875c0bf7c9537e3f296a8ec64853ef"
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"


### PR DESCRIPTION
## Why ?

Currently `new Date` is used to format dates for base theme posts. This works when the post date is in `yyyy-mm-dd` (e.g. `2016-01-22`) format, but for example Safari will throw an error if you try to add hours and minutes (without seconds, e.g. `2016-01-22 14:31`) and seems to also return `Invalid Date` for many of the combinations that I have tried. Chrome seems to be a bit more relaxed with the dates, but will also return `Invalid Date` for some date combinations.
 
I think that since it is not obvious which formatting style throws and which doesn't, it would be good to try to support [the formats that are mentioned in this blog post](http://www.pelagodesign.com/blog/2009/05/20/iso-8601-date-validation-that-doesnt-suck/). 

## How does using date-fns change the situation?

Date-fns' parse also accepts dates that are not in the full ISO 8601 format:

```
Convert the given argument to an instance of Date.

If the argument is an instance of Date, the function returns its clone.

If the argument is a number, it is treated as a timestamp.

If an argument is a string, the function tries to parse it. 
Function accepts complete ISO 8601 formats as well as partial implementations. ISO 8601: http://en.wikipedia.org/wiki/ISO_8601

If all above fails, the function passes the given argument to Date constructor.
```
https://github.com/date-fns/date-fns/blob/master/src/parse/index.js

## Change in file size

Before:
```
-rw-r--r--   1 krister  staff   298K Apr  3 21:51 phenomic.browser.ba0bbd0527652669ed85.js
-rw-r--r--   1 krister  staff    87K Apr  3 21:52 phenomic.browser.ba0bbd0527652669ed85.js.gz
```

After:
```
-rw-r--r--   1 krister  staff   301K Apr  3 21:54 phenomic.browser.ef41c4d45bc213bf0f62.js
-rw-r--r--   1 krister  staff    88K Apr  3 21:55 phenomic.browser.ef41c4d45bc213bf0f62.js.gz
```


