### PR TITLE
Windows example on GitHub Pages page produces different behaviour

### DIFF
--- a/docs/content/docs/usage/gh-pages.md
+++ b/docs/content/docs/usage/gh-pages.md
@@ -81,7 +81,7 @@ IF EXIST .git (RMDIR .git /s /q)
 git init && ^
 git add . && ^
 git commit -m "Deploy of GitHub Pages" && ^
-git push --force "%GIT_DEPLOY_REPO%" master
+git push --force "%GIT_DEPLOY_REPO%" master:gh-pages
 ```
 
 ---


### PR DESCRIPTION
Fixed the Windows example so that it pushes to the remote gh_pages branch as per the macos/linux example.
