### PR TITLE
Fixed (I think) broken link in this README

### DIFF
--- a/src/redux/modules/README.md
+++ b/src/redux/modules/README.md
@@ -1,1 +1,1 @@
-https://github.com/erikras/redux/modules-modular-redux
+https://github.com/erikras/ducks-modular-redux


### PR DESCRIPTION
While looking into adding reducers, I noticed the link in this README is broken.
I've updated it with what I think is the correct link, but please double-check.