### PR TITLE
Fix HRM hot reload on windows (#779, #973)

### DIFF
--- a/src/loader/index.js
+++ b/src/loader/index.js
@@ -65,7 +65,7 @@ const loader = function(input: string) {
   const dataUrl = resourceUrl + "." + contentHash + ".json"
 
   const metadata = {
-    __filename: relativePath,
+    __filename: pathToUri(relativePath),
     __url: pathToUri("/", url),
     __resourceUrl: pathToUri("/", resourceUrl),
     __dataUrl: pathToUri("/", dataUrl),


### PR DESCRIPTION
Normalize the `__filename` path of the phenomic loader to match webpack context filenames.

Applies fix proposed by @mktange in #974

Fixes #973, #779