### PR TITLE
Pass react-router location property to layouts

### DIFF
--- a/src/components/PageContainer/component.js
+++ b/src/components/PageContainer/component.js
@@ -24,6 +24,7 @@ type Props = {
   getPage: Function,
   setPageNotFound: Function,
   logger: Object,
+  location: Object,
 }
 
 type Context = {
@@ -281,6 +282,7 @@ class PageContainer extends Component<DefaultProps, Props, void> {
           // head will be overwritten by "page"
           // (since page contains a head when loaded)
           head={ partialPageHead }
+          location={ props.location }
           { ...page }
         />
       )


### PR DESCRIPTION
I propose this change to pass on react-router's **location** property to the chosen layout component, so that the layout can access query string parameters and other location information as React properties.

Without this modification, I have had to use getChildContext in AppContainer to pass the location object to the layout, which doesn't work so well with the React property system. My goal is to make it easy to use componentWillReceiveProps() to react to query string changes.