### PR TITLE
Update gh-pages.md

### DIFF
--- a/docs/content/docs/usage/gh-pages.md
+++ b/docs/content/docs/usage/gh-pages.md
@@ -190,7 +190,7 @@ With only `repo` or `public_repo` scopes.
 *Note: replace `{YOU/YOUR_REPO}` and `{YOUR_TOKEN}`.*
 
 ```sh
-yarn i -g travis-encrypt
+yarn global add travis-encrypt
 travis-encrypt --add --repo {YOU/YOUR_REPO} GITHUB_TOKEN={YOUR_TOKEN}
 ```
 


### PR DESCRIPTION
Update documentation to avoid "error `install` has been replaced with `add` to add new dependencies. Run `yarn global add travis-encrypt` instead."